### PR TITLE
Fix: Misleading implementation of the protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,26 +155,31 @@ import (
   "os/signal"
   "syscall"
 
-  "github.com/rafaeljusto/gomaxscale"
+  "github.com/rafaeljusto/gomaxscale/v2"
 )
 
 func main() {
   consumer := gomaxscale.NewConsumer("127.0.0.1:4001", "example", "users",
     gomaxscale.WithAuth("maxuser", "maxpwd"),
   )
-  dataStream, err := consumer.Start()
+  err := consumer.Start()
   if err != nil {
     log.Fatal(err)
   }
   defer consumer.Close()
 
-  fmt.Printf("started consuming events from database '%s' table '%s'\n",
-    dataStream.Database, dataStream.Table)
+  fmt.Println("start consuming events")
 
   done := make(chan bool)
   go func() {
-    consumer.Process(func(event gomaxscale.Event) {
-      fmt.Printf("event '%s' detected\n", event.Type)
+    consumer.Process(func(event gomaxscale.CDCEvent) {
+      switch e := event.(type) {
+      case gomaxscale.DDLEvent:
+        fmt.Printf("ddl event detected on database '%s' and table '%s'\n",
+          e.Database, e.Table)
+      case gomaxscale.DMLEvent:
+        fmt.Printf("dml '%s' event detected\n", e.Type)
+      }
     })
     done <- true
   }()

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rafaeljusto/gomaxscale
+module github.com/rafaeljusto/gomaxscale/v2
 
 go 1.17


### PR DESCRIPTION
* Correct naming CDC events (DDL and DML events)

* DDL and DML events can happen at any time. Until now there was a misconception that the DDL event would be sent only at startup.

* Major refactoring of the stream algorithm to handle all different network scenarios.

* Added tests for startup and events processing.

This change is not backwards compatible, as the DDL event won't be returned by the `Start` call anymore. Also, the `Process` method will now handle an interface instead of a concrete type. For all those reasons the Go module version was increased.