### PR TITLE
Enhancement: Add missing package documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Package gomaxscale is a CDC consumer for MaxScale.
+package gomaxscale


### PR DESCRIPTION
The package documentation is used by Go docs to generate a short description of the package when navigating.