### PR TITLE
Feature: New stats option to extract information about processing time

### DIFF
--- a/gomaxscale_options.go
+++ b/gomaxscale_options.go
@@ -16,6 +16,10 @@ type Options struct {
 		read    time.Duration
 		write   time.Duration
 	}
+	stats struct {
+		period time.Duration
+		ticker func(Stats)
+	}
 	uuid       string
 	version    *int
 	gtid       string // Requested GTID position
@@ -54,6 +58,15 @@ func WithTimeout(readTimeout, writeTimeout time.Duration) func(*Options) {
 	return func(o *Options) {
 		o.timeouts.read = readTimeout
 		o.timeouts.write = writeTimeout
+	}
+}
+
+// WithStats enables statistics in the library. The ticker callback is called
+// every period of time with information about events and processing time.
+func WithStats(period time.Duration, ticker func(Stats)) func(*Options) {
+	return func(o *Options) {
+		o.stats.period = period
+		o.stats.ticker = ticker
 	}
 }
 

--- a/gomaxscale_test.go
+++ b/gomaxscale_test.go
@@ -288,6 +288,14 @@ func BenchmarkConsumer_Process(b *testing.B) {
 	consumer := gomaxscale.NewConsumer(serverAddr, "database", "table",
 		gomaxscale.WithTimeout(10*time.Millisecond, 10*time.Millisecond),
 		gomaxscale.WithLogger(loggerMock),
+		gomaxscale.WithStats(time.Second, func(stats gomaxscale.Stats) {
+			var averageProcessingTime time.Duration
+			if stats.NumberOfEvents > 0 {
+				averageProcessingTime = stats.ProcessingTime / time.Duration(stats.NumberOfEvents)
+			}
+			b.Logf("stats: %d events/second, average processing time %s",
+				stats.NumberOfEvents, averageProcessingTime)
+		}),
 	)
 	if err = consumer.Start(); err != nil {
 		b.Fatalf("failed to start consumer: %s", err)

--- a/types.go
+++ b/types.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
+	"time"
 )
 
 // CDCEventType is the type of the event.
@@ -191,4 +193,21 @@ type DMLEvent struct {
 // EventType returns the type of the event.
 func (d DMLEvent) EventType() CDCEventType {
 	return CDCEventTypeDML
+}
+
+// Stats stores information about the running library in a specific period of
+// time.
+type Stats struct {
+	NumberOfEvents int64
+	ProcessingTime time.Duration
+}
+
+func (s *Stats) add(processingTime time.Duration) {
+	atomic.AddInt64(&s.NumberOfEvents, 1)
+	atomic.AddInt64((*int64)(&s.ProcessingTime), processingTime.Nanoseconds())
+}
+
+func (s *Stats) reset() {
+	atomic.StoreInt64(&s.NumberOfEvents, 0)
+	atomic.StoreInt64((*int64)(&s.ProcessingTime), 0)
 }


### PR DESCRIPTION
To have a better idea of how many events are being processed and how long is it taking a new option is now available to periodically inform the caller.