### PR TITLE
Fix: Godoc link still referencing version 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gomaxscale
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/rafaeljusto/gomaxscale.svg)](https://pkg.go.dev/github.com/rafaeljusto/gomaxscale)
+[![Go Reference](https://pkg.go.dev/badge/github.com/rafaeljusto/gomaxscale/v2.svg)](https://pkg.go.dev/github.com/rafaeljusto/gomaxscale/v2)
 [![license](http://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rafaeljusto/gomaxscale/master/LICENSE)
 
 Go library that allows consuming from [MaxScale](https://mariadb.com/kb/en/maxscale/)


### PR DESCRIPTION
Update the Godoc link from README to use the new version 2 reference.