### PR TITLE
Fix: Network timeout in mocked server when running benchmark

### DIFF
--- a/gomaxscale_test.go
+++ b/gomaxscale_test.go
@@ -479,7 +479,10 @@ func (m *maxScaleServerMock) handleConnection(conn net.Conn) {
 			break
 		}
 		if err := encoder.Encode(event); err != nil {
-			_, _ = writeString(conn, "ERR failed encoding event: %s", err)
+			// only write error back if the connection is still open
+			if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+				_, _ = writeString(conn, "ERR failed encoding event: %s", err)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
When the consumer closes the connection while the server is still writing data a timeout error is raised. Handling the timeout error in the mocked server solves this issue.