### PR TITLE
Fix: Comment links and missing references

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ FLUSH PRIVILEGES;
 DROP DATABASE IF EXISTS example;
 CREATE DATABASE IF NOT EXISTS example;
 
--- Allow MaxScale user to run 'SHOW CREATE TABLE' for DDL events
+-- Allows MaxScale user to run 'SHOW CREATE TABLE' for DDL events
+-- https://mariadb.com/kb/en/mariadb-maxscale-6-avrorouter/#avro-schema-generator
 GRANT SELECT ON example.* TO 'maxuser'@'%';
 FLUSH PRIVILEGES;
 
@@ -78,6 +79,7 @@ INSERT INTO `users` (`name`, `email`) VALUES ('Jane Doe', 'jane@doe.com');
 ### maxscale.cnf
 
 MaxScale configuration to configure the [Avro router](https://mariadb.com/kb/en/mariadb-maxscale-6-avrorouter/)
+([direct replication mode](https://mariadb.com/kb/en/mariadb-maxscale-6-avrorouter/#direct-replication-mode))
 and expose a listener so `gomaxscale` can retrieve the information.
 
 ```dosini

--- a/types.go
+++ b/types.go
@@ -26,7 +26,7 @@ type CDCEvent interface {
 
 // DDLEvent is a MaxScale DDL event.
 //
-// https://github.com/mariadb-corporation/MaxScale/blob/6.2/Documentation/Routers/KafkaCDC.md#overview
+// https://github.com/mariadb-corporation/MaxScale/blob/maxscale-6.2.4/Documentation/Routers/KafkaCDC.md#overview
 type DDLEvent struct {
 	Namespace string          `json:"namespace"`
 	Type      string          `json:"type"`
@@ -168,7 +168,7 @@ func (d DDLEventFieldValueEnum) Type() DDLEventFieldType {
 
 // DMLEvent is a MaxScale DML event.
 //
-// https://github.com/mariadb-corporation/MaxScale/blob/6.2/Documentation/Routers/KafkaCDC.md#overview
+// https://github.com/mariadb-corporation/MaxScale/blob/maxscale-6.2.4/Documentation/Routers/KafkaCDC.md#overview
 type DMLEvent struct {
 	Domain      int    `json:"domain"`
 	ServerID    int    `json:"server_id"`


### PR DESCRIPTION
Some links were broken in source-code comments referencing an already removed branch in Maxscale repository. Now the link will reference a repository tag.

Also added some extra links into README to clarify configuration decisions for the example.